### PR TITLE
updated an error message for parsing documents

### DIFF
--- a/folia/main.py
+++ b/folia/main.py
@@ -7187,7 +7187,7 @@ class Document(object):
         elif 'tree' in kwargs:
             self.parsexml(kwargs['tree'])
         else:
-            raise Exception("No ID, filename or tree specified")
+            raise Exception("No ID, filename or tree specified. Or the argument name is wrong.")
 
         self.doneparsing = True #indicates that the document is done parsing
 


### PR DESCRIPTION
The usage of args and kwargs prevent returning proper error messages when a used argument name does not exist.