### PR TITLE
Prevent tripping over comments

### DIFF
--- a/folia/main.py
+++ b/folia/main.py
@@ -8633,6 +8633,9 @@ class Document(object):
                     raise ParseError("Found extra leading text '" + node.text.strip() + "' in handling of <FoLiA> @ line " + str(node.sourceline))
 
                 for subnode in node:
+                    # don't trip over comments
+                    if isinstance(subnode, ElementTree._Comment):
+                        continue
                     if subnode.text and subnode.text.strip():
                         raise ParseError("Found extra leading text '" + subnode.text.strip() + "' in handling of <"+ subnode.tag+"> @ line " + str(node.sourceline))
                     if subnode.tag == '{' + NSFOLIA + '}metadata':

--- a/folia/tests/test_comment.py
+++ b/folia/tests/test_comment.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import unittest
+import folia.main as folia
+
+
+def test_parse_comments():
+    folia.Document(
+        string="""<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="folia.xsl"?>
+<!-- Foo -->
+<FoLiA xmlns="http://ilk.uvt.nl/folia" version="2.0" xml:id="example">
+  <!-- Foo -->
+  <text>
+    <!-- Foo -->
+    <p>
+      <!-- Foo -->
+      <t><!-- Foo -->Dit is een test.</t>
+    <!-- Foo -->
+    </p>
+    <!-- Foo -->
+  </text>
+  <!-- Foo -->
+</FoLiA>
+<!-- Foo -->
+""",
+        autodeclare=True,
+        loadsetdefinitions=False,
+    )


### PR DESCRIPTION
Hi! I've encountered a small bug where a comment directly after the `<FoLiA>`-tag caused a parsing error.